### PR TITLE
Simplify some demo params

### DIFF
--- a/components/MainHeader.tsx
+++ b/components/MainHeader.tsx
@@ -154,7 +154,6 @@ const MainHeader: React.FC<{
           setCustomerForm({
             ...customerForm,
             email: generateDemoEmail({
-              productFlow: newProductFlow,
               customerType
             })
           })
@@ -173,7 +172,6 @@ const MainHeader: React.FC<{
           setCustomerForm({
             ...customerForm,
             email: generateDemoEmail({
-              productFlow,
               customerType: newCustomerType
             })
           })

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -52,9 +52,20 @@ const Checkout: React.FC<{
     const { order, secret } = await orderRes.json()
     console.log('orderId & secret', order.id, secret)
 
+    let offerType
+    switch (productFlow) {
+      case ProductFlow.BNPL_ONLY:
+      case ProductFlow.PAY_NOW_ONLY:
+        offerType = productFlow
+        break
+      default:
+        break
+    }
+
     // @ts-ignore
     window.initializeSlope({
       intentSecret: secret,
+      offerType,
       // TODO: add support for skipTerms field
       onSuccess: async (successResp) => {
         // TODO: fix dupe events

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,56 +1,56 @@
-import React, { useState } from 'react';
-import { Button, Grid, Title, Text, Group } from '@mantine/core';
-import { useRouter } from 'next/router';
-import { IconCreditCard, IconShoppingCart } from '@tabler/icons';
-import CustomerForm from '../components/CustomerForm';
-import OrderSummary from '../components/OrderSummary';
-import ErrorAlert from '../components/ErrorAlert';
-import { getProducts, getTotals } from '../utils/products';
-import { ProductFlow } from '../utils/email';
+import React, { useState } from 'react'
+import { Button, Grid, Title, Text, Group } from '@mantine/core'
+import { useRouter } from 'next/router'
+import { IconCreditCard, IconShoppingCart } from '@tabler/icons'
+import CustomerForm from '../components/CustomerForm'
+import OrderSummary from '../components/OrderSummary'
+import ErrorAlert from '../components/ErrorAlert'
+import { getProducts, getTotals } from '../utils/products'
+import { ProductFlow } from '../utils/email'
 
 const Checkout: React.FC<{
-  customerForm: Record<string, any>;
-  setCustomerForm: any;
-  productFlow: ProductFlow;
+  customerForm: Record<string, any>
+  setCustomerForm: any
+  productFlow: ProductFlow
 }> = ({ customerForm, setCustomerForm, productFlow }) => {
-  const router = useRouter();
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(null);
+  const router = useRouter()
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
 
   const onPay = async () => {
-    setLoading(true);
+    setLoading(true)
 
     const customerResp = await fetch('/api/create-customer', {
       method: 'POST',
-      body: JSON.stringify(customerForm),
-    });
+      body: JSON.stringify(customerForm)
+    })
 
-    const customerJson = await customerResp.json();
+    const customerJson = await customerResp.json()
 
     if (!customerJson.customer) {
-      setLoading(false);
-      return setError(customerJson);
+      setLoading(false)
+      return setError(customerJson)
     }
     console.log(
       'customerId & secret',
       customerJson.customer.id,
       customerJson.secret
-    );
+    )
 
-    const products = getProducts(customerForm.product);
-    const totals = getTotals(products);
+    const products = getProducts(customerForm.product)
+    const totals = getTotals(products)
 
     const orderRes = await fetch('/api/create-order', {
       method: 'POST',
       body: JSON.stringify({
         ...customerForm,
         customerId: customerJson.customer.id,
-        total: totals.total,
-      }),
-    });
+        total: totals.total
+      })
+    })
 
-    const { order, secret } = await orderRes.json();
-    console.log('orderId & secret', order.id, secret);
+    const { order, secret } = await orderRes.json()
+    console.log('orderId & secret', order.id, secret)
 
     // @ts-ignore
     window.initializeSlope({
@@ -59,21 +59,21 @@ const Checkout: React.FC<{
       onSuccess: async (successResp) => {
         // TODO: fix dupe events
         if (successResp.order && successResp.order.id) {
-          router.push('/success');
+          router.push('/success')
         }
       },
       onFailure: (err) => {
-        console.error(err);
-        alert(err.message);
+        console.error(err)
+        alert(err.message)
       },
       onClose: () => {
-        setLoading(false);
+        setLoading(false)
       },
-      onEvent: console.log,
-    });
+      onEvent: console.log
+    })
     // @ts-ignore
-    window.Slope.open();
-  };
+    window.Slope.open()
+  }
 
   const slopeButton = (
     <Button
@@ -89,7 +89,7 @@ const Checkout: React.FC<{
         ? 'Pay later with Slope'
         : 'Pay with Slope'}
     </Button>
-  );
+  )
 
   return (
     <>
@@ -142,7 +142,7 @@ const Checkout: React.FC<{
         </Grid.Col>
       </Grid>
     </>
-  );
-};
+  )
+}
 
-export default Checkout;
+export default Checkout

--- a/utils/email.ts
+++ b/utils/email.ts
@@ -5,7 +5,9 @@ export enum ProductFlow {
   PAY_NOW_ONLY = 'pay_now',
   BNPL_AND_PAY_NOW = 'bnpl_pay_now',
   // Only goes through prequalification, and then closes. Requires no order context.
-  STANDALONE_PREQUAL = 'standalone_prequal'
+  STANDALONE_PREQUAL = 'standalone_prequal',
+  // Manage customer payment methods.
+  MANAGE_CUSTOMER_PAYMENT_METHODS = 'manage_customer_pymnt_methods'
 }
 
 export enum CustomerType {
@@ -17,23 +19,11 @@ export enum CustomerType {
 export const QUALIFIED_EMAIL_SUFFIX = '+skip-pre_qualify'
 
 export const generateDemoEmail = ({
-  productFlow,
   customerType
 }: {
-  productFlow: ProductFlow
   customerType: CustomerType
 }) => {
   let email = 'demo'
-  switch (productFlow) {
-    case ProductFlow.PAY_NOW_ONLY:
-      email += '+terms-pay_now'
-      break
-    case ProductFlow.BNPL_ONLY:
-      email += '+terms-bnpl'
-      break
-    default:
-      break
-  }
 
   switch (customerType) {
     case CustomerType.PREQUALIFIED:

--- a/utils/products.ts
+++ b/utils/products.ts
@@ -41,13 +41,12 @@ export const getTotals = (products) => {
   return {
     subtotal,
     taxes,
-    total,
+    total
   }
 }
 
 export const formatCurrency = (number) => {
-  return new Intl.NumberFormat(
-    'en-US',
-    { style: 'currency', currency: 'USD' }).format(number / 100.0
-  ).toString();
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' })
+    .format(number / 100.0)
+    .toString()
 }


### PR DESCRIPTION
Prettifies, and simplifies some of the logic to use slope.js's new `offerType` param instead of email shortcuts to control demo params.

The `offerType` param is closer to what a sandbox merchant would play around with.