### PR TITLE
add in new test email shortcuts

### DIFF
--- a/components/MainHeader.tsx
+++ b/components/MainHeader.tsx
@@ -105,10 +105,52 @@ const MainHeader: React.FC<{
     { label: 'Qualified', value: CustomerType.PREQUALIFIED },
     { label: 'New', value: CustomerType.NEW },
     { label: 'Ineligible', value: CustomerType.INELIGIBLE },
-    { label: 'Reject: Order max', value: CustomerType.ORDER_MAX },
-    { label: 'Reject: Order min', value: CustomerType.ORDER_MIN },
-    { label: 'Reject: Outstanding orders', value: CustomerType.OUTSTANDING },
-    { label: 'Reject: Overdue', value: CustomerType.OVERDUE }
+    { label: 'Prefilled Identity', value: CustomerType.MASK_KYB },
+    {
+      label: 'Order max',
+      value: CustomerType.ORDER_MAX,
+      group: 'Order rejection reasons'
+    },
+    {
+      label: 'Order min',
+      value: CustomerType.ORDER_MIN,
+      group: 'Order rejection reasons'
+    },
+    {
+      label: 'Outstanding orders',
+      value: CustomerType.OUTSTANDING,
+      group: 'Order rejection reasons'
+    },
+    {
+      label: 'Overdue',
+      value: CustomerType.OVERDUE,
+      group: 'Order rejection reasons'
+    },
+    {
+      label: 'Same limit',
+      value: CustomerType.FORCE_REEVAL,
+      group: 'Reevaluation possibilities'
+    },
+    {
+      label: 'Increased',
+      value: CustomerType.FORCE_REEVAL_INCREASED,
+      group: 'Reevaluation possibilities'
+    },
+    {
+      label: 'Decreased, approved',
+      value: CustomerType.FORCE_REEVAL_DECREASE_APPROVED,
+      group: 'Reevaluation possibilities'
+    },
+    {
+      label: 'Decrease, rejected',
+      value: CustomerType.FORCE_REEVAL_DECREASE_REJECTED,
+      group: 'Reevaluation possibilities'
+    },
+    {
+      label: 'Ineligible',
+      value: CustomerType.FORCE_REEVAL_INELIGIBLE,
+      group: 'Reevaluation possibilities'
+    }
   ]
 
   const mItem = (

--- a/utils/email.ts
+++ b/utils/email.ts
@@ -17,7 +17,13 @@ export enum CustomerType {
   ORDER_MAX = '+orders-total-max',
   ORDER_MIN = '+orders-total-min',
   OUTSTANDING = '+outstanding-orders',
-  OVERDUE = '+orders-overdue'
+  OVERDUE = '+orders-overdue',
+  FORCE_REEVAL = '+force-reeval',
+  FORCE_REEVAL_INCREASED = '+force-reeval_increased',
+  FORCE_REEVAL_DECREASE_APPROVED = '+force-reeval_decrease_approved',
+  FORCE_REEVAL_DECREASE_REJECTED = '+force-reeval_decrease_rejected',
+  FORCE_REEVAL_INELIGIBLE = '+force-reeval_ineligible',
+  MASK_KYB = '+mask-kyb'
 }
 
 export const generateDemoEmail = ({
@@ -27,17 +33,8 @@ export const generateDemoEmail = ({
 }) => {
   let email = 'demo'
 
-  switch (customerType) {
-    case CustomerType.PREQUALIFIED:
-    case CustomerType.INELIGIBLE:
-    case CustomerType.ORDER_MAX:
-    case CustomerType.ORDER_MIN:
-    case CustomerType.OUTSTANDING:
-    case CustomerType.OVERDUE:
-      email += customerType as string
-      break
-    default:
-      break
+  if (Object.values(CustomerType).includes(customerType)) {
+    email += customerType as string
   }
   email += '@slope.so'
   return email


### PR DESCRIPTION
Adds updated test email shortcuts that match backend, here: https://github.com/Slope-Tech/backend/blob/main/src/underwriting/decisioning/offer/test-shortcuts.decisioner.ts#L10-L30

Ideally this would pull directly from the repo instead of needing to copy and paste.